### PR TITLE
Stuarloy

### DIFF
--- a/templates/topologies/net-local-admin.yaml
+++ b/templates/topologies/net-local-admin.yaml
@@ -148,7 +148,7 @@ Resources:
         - - !Ref AWS::NoValue
       OperationPreferences:
         MaxConcurrentPercentage: 100
-        FailureTolerancePercentage: 100
+        FailureTolerancePercentage: 0
         RegionConcurrencyType: PARALLEL
       Capabilities:
         - CAPABILITY_IAM

--- a/templates/topologies/net-local-admin.yaml
+++ b/templates/topologies/net-local-admin.yaml
@@ -75,6 +75,8 @@ Resources:
                   - lambda:CreateFunction
                   - lambda:DeleteFunction
                   - lambda:InvokeFunction
+                  - lambda:TagResource
+                  - lambda:GetFunction
                   - ram:CreateResourceShare
                   - ram:DeleteResourceShare
                   - ram:TagResource


### PR DESCRIPTION
*Description of changes:*
When testing this I found that the admin stacks failed to deploy in secondary regions due to the cloudformation execution role missing a couple of lambda permissions. I have added the required permissions.

Additionally the FailureTolerancePercentage for SecondaryAdminRegionsStackSet was set to 100. This led to these failures being ignored and an attempt being made to deploy all of the member stacks which subsequently fail. This takes time and manual intervention to unwind, therefore I have set this value to 0 to allow the deployment to fail fast.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
